### PR TITLE
Lumen Support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
     },
     "require": {
         "php": ">=5.6.0",
-        "laravel/framework": "5.0.*",
+        "illuminate/support": "~5.0",
         "phpspec/phpspec": "~2.1"
     }
 }


### PR DESCRIPTION
It looks like the only dependency is Illuminate\Support\ServiceProvider, so no need to require the whole Laravel framework.
