### PR TITLE
Make phpspec a development requirement instead of a hard requirement.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,9 @@
     },
     "require": {
         "php": ">=5.5.0",
-        "illuminate/support": "~5.0",
+        "illuminate/support": "~5.0"
+    },
+    "require-dev": {
         "phpspec/phpspec": "~2.1"
     }
 }


### PR DESCRIPTION
From Composer: https://getcomposer.org/doc/04-schema.md#require-dev

> Lists packages required for developing this package, or running tests, etc.
>   The dev requirements of the root package are installed by default.
